### PR TITLE
Add missing auth and component modules

### DIFF
--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -1,0 +1,5 @@
+import client from './client';
+
+export async function ping() {
+  return client.get('/ping');
+}

--- a/src/components/LoginForm.jsx
+++ b/src/components/LoginForm.jsx
@@ -1,0 +1,5 @@
+export default function LoginForm({ onLogin }) {
+  return (
+    <button onClick={onLogin}>Login</button>
+  );
+}

--- a/src/components/ReportForm.jsx
+++ b/src/components/ReportForm.jsx
@@ -1,0 +1,13 @@
+export default function ReportForm({ onCreated }) {
+  function handleSubmit(e) {
+    e.preventDefault();
+    if (onCreated) onCreated();
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <input placeholder="Report" />
+      <button type="submit">Submit</button>
+    </form>
+  );
+}

--- a/src/components/ReportList.jsx
+++ b/src/components/ReportList.jsx
@@ -1,0 +1,7 @@
+export default function ReportList() {
+  return (
+    <ul>
+      <li>No reports yet</li>
+    </ul>
+  );
+}


### PR DESCRIPTION
## Summary
- implement `src/api/auth.js` with a `ping` helper
- add stub UI components for login and reports

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_684ad06fd14c8322a9b5b0a1365b2ece