### PR TITLE
Replace internationalized domain with ASCII domain

### DIFF
--- a/src/api/client.js
+++ b/src/api/client.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 const client = axios.create({
-  baseURL: 'https://api.dindomän.se',
+  baseURL: 'https://api.dindoman.se',
   withCredentials: true,
 });
 


### PR DESCRIPTION
## Summary
- switch API base URL to use ASCII-only domain

## Testing
- `grep -n dindomän -R`

------
https://chatgpt.com/codex/tasks/task_b_684ad1bfae408322b65d43f1ea9ea916