### PR TITLE
Update docs for API base URL env

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,26 @@ report-tester/
 
 ## API client
 
-`src/api/client.js` creates an Axios client with the base URL `https://app.leasify.se/api/v3`. It adds an interceptor that automatically attaches a bearer token from `localStorage` to every request.
+`src/api/client.js` creates an Axios client. By default it targets the Leasify
+production API (`https://app.leasify.se/api/v3`), but the base URL can be
+overridden by setting the environment variable `VITE_API_BASE_URL`. Vite will
+pick up this value from your shell or an `.env` file at the project root. The
+client also installs an interceptor that automatically attaches a bearer token
+from `localStorage` to every request.
+
+## Environment variables
+
+The application reads configuration from Vite environment variables. To change
+the API base URL, define `VITE_API_BASE_URL` before running the dev server or
+build. Create an `.env` file in the project root or export the variable in your
+shell:
+
+```bash
+# .env
+VITE_API_BASE_URL=https://my-api.example.com/api/v3
+```
+
+When undefined, the client will default to Leasify's production API.
 
 ## Development
 


### PR DESCRIPTION
## Summary
- document override of API base URL via `VITE_API_BASE_URL`
- add section on environment variables with example

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6863d940254c83229c2bed1805253c3e