### PR TITLE
Implement email-based login

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,13 @@ VITE_API_BASE_URL=https://my-api.example.com/api/v3
 
 When undefined, the client will default to Leasify's production API.
 
+## Authentication
+
+Logga in med e-postadress och lösenord mot `/login`-endpointen. Svaret
+innehåller en token som ska sparas i `localStorage` under nyckeln
+`token`. Axios-klienten läser automatiskt detta värde och skickar det som
+`Bearer` i `Authorization`-headern för alla efterföljande anrop.
+
 ## Development
 
 Install dependencies and start the development server:

--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -3,3 +3,9 @@ import client from './client';
 export function ping() {
   return client.get('/ping');
 }
+
+// Log in with email and password. The API will return a token that can be stored
+// in localStorage and used as a bearer token for subsequent requests.
+export function login(email, password) {
+  return client.post('/login', { email, password });
+}

--- a/src/components/LoginForm.jsx
+++ b/src/components/LoginForm.jsx
@@ -1,14 +1,14 @@
 import { useState } from 'react';
-import client from '../api/client';
+import { login } from '../api/auth';
 
 export default function LoginForm({ onLogin }) {
-  const [username, setUsername] = useState('');
+  const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
 
   const handleSubmit = async (e) => {
     e.preventDefault();
     try {
-      const { data } = await client.post('/login', { username, password });
+      const { data } = await login(email, password);
       localStorage.setItem('token', data.token);
       if (onLogin) onLogin();
     } catch (err) {
@@ -46,9 +46,9 @@ export default function LoginForm({ onLogin }) {
       <form onSubmit={handleSubmit} className="space-y-2">
         <input
           className="border p-2 w-full"
-          placeholder="Username"
-          value={username}
-          onChange={(e) => setUsername(e.target.value)}
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
         />
         <input
           type="password"


### PR DESCRIPTION
## Summary
- implement `login` helper in `src/api/auth.js`
- switch LoginForm to use email and new login helper
- document login steps in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6863db109a448322984d88ae35c6e5f5