### PR TITLE
Add device name env support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+VITE_API_BASE_URL=https://app.leasify.se/api/v3
+VITE_DEVICE_NAME=MyDevice

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ node_modules
 dist
 .DS_Store
 
-node_modules
+.env

--- a/README.md
+++ b/README.md
@@ -36,15 +36,19 @@ from `localStorage` to every request.
 
 The application reads configuration from Vite environment variables. To change
 the API base URL, define `VITE_API_BASE_URL` before running the dev server or
-build. Create an `.env` file in the project root or export the variable in your
-shell:
+build. You can also specify a device name that will be sent when logging in by
+setting `VITE_DEVICE_NAME`. Create an `.env` file in the project root or export
+these variables in your shell:
 
 ```bash
 # .env
 VITE_API_BASE_URL=https://my-api.example.com/api/v3
+VITE_DEVICE_NAME=MyDevice
 ```
 
 When undefined, the client will default to Leasify's production API.
+When `VITE_DEVICE_NAME` is not set, login requests will omit the `device_name`
+parameter.
 
 ## Authentication
 

--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -7,5 +7,8 @@ export function ping() {
 // Log in with email and password. The API will return a token that can be stored
 // in localStorage and used as a bearer token for subsequent requests.
 export function login(email, password) {
-  return client.post('/login', { email, password });
+  const deviceName = import.meta?.env?.VITE_DEVICE_NAME || process.env.VITE_DEVICE_NAME;
+  const payload = { email, password };
+  if (deviceName) payload.device_name = deviceName;
+  return client.post('/login', payload);
 }

--- a/src/api/auth.test.js
+++ b/src/api/auth.test.js
@@ -1,0 +1,36 @@
+import MockAdapter from 'axios-mock-adapter';
+import client from './client.js';
+import { login } from './auth.js';
+
+describe('login', () => {
+  it('includes device_name when VITE_DEVICE_NAME is set', async () => {
+    process.env.VITE_DEVICE_NAME = 'MyDevice';
+    const mock = new MockAdapter(client);
+    mock.onPost('/login').reply(200, { token: 'ok' });
+
+    await login('user', 'pass');
+    const request = mock.history.post[0];
+    expect(JSON.parse(request.data)).toEqual({
+      email: 'user',
+      password: 'pass',
+      device_name: 'MyDevice',
+    });
+
+    mock.restore();
+    delete process.env.VITE_DEVICE_NAME;
+  });
+
+  it('omits device_name when VITE_DEVICE_NAME is not set', async () => {
+    const mock = new MockAdapter(client);
+    mock.onPost('/login').reply(200, { token: 'ok' });
+
+    await login('user', 'pass');
+    const request = mock.history.post[0];
+    expect(JSON.parse(request.data)).toEqual({
+      email: 'user',
+      password: 'pass',
+    });
+
+    mock.restore();
+  });
+});


### PR DESCRIPTION
## Summary
- add `.env.example` with `VITE_DEVICE_NAME`
- document `VITE_DEVICE_NAME` in README
- ignore local `.env`
- include device name in login requests
- test login behaviour with and without `VITE_DEVICE_NAME`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6863dcf2e8748322a8ae891619470f27