### PR TITLE
Fix login on browsers

### DIFF
--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -7,7 +7,9 @@ export function ping() {
 // Log in with email and password. The API will return a token that can be stored
 // in localStorage and used as a bearer token for subsequent requests.
 export function login(email, password) {
-  const deviceName = import.meta?.env?.VITE_DEVICE_NAME || process.env.VITE_DEVICE_NAME;
+  const deviceName =
+    import.meta?.env?.VITE_DEVICE_NAME ||
+    (typeof process !== 'undefined' ? process.env.VITE_DEVICE_NAME : undefined);
   const payload = { email, password };
   if (deviceName) payload.device_name = deviceName;
   return client.post('/login', payload);


### PR DESCRIPTION
## Summary
- handle when `process` is undefined in login API helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6863de626c0c832281779285cc7367df