### PR TITLE
Rename env vars and show login errors

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
-VITE_API_BASE_URL=https://app.leasify.se/api/v3
-VITE_DEVICE_NAME=MyDevice
+API_BASE_URL=https://app.leasify.se/api/v3
+DEVICE_NAME=MyDevice

--- a/README.md
+++ b/README.md
@@ -27,27 +27,27 @@ report-tester/
 
 `src/api/client.js` creates an Axios client. By default it targets the Leasify
 production API (`https://app.leasify.se/api/v3`), but the base URL can be
-overridden by setting the environment variable `VITE_API_BASE_URL`. Vite will
+overridden by setting the environment variable `API_BASE_URL`. Vite will
 pick up this value from your shell or an `.env` file at the project root. The
 client also installs an interceptor that automatically attaches a bearer token
 from `localStorage` to every request.
 
 ## Environment variables
 
-The application reads configuration from Vite environment variables. To change
-the API base URL, define `VITE_API_BASE_URL` before running the dev server or
+The application reads configuration from environment variables. To change
+the API base URL, define `API_BASE_URL` before running the dev server or
 build. You can also specify a device name that will be sent when logging in by
-setting `VITE_DEVICE_NAME`. Create an `.env` file in the project root or export
+setting `DEVICE_NAME`. Create an `.env` file in the project root or export
 these variables in your shell:
 
 ```bash
 # .env
-VITE_API_BASE_URL=https://my-api.example.com/api/v3
-VITE_DEVICE_NAME=MyDevice
+API_BASE_URL=https://my-api.example.com/api/v3
+DEVICE_NAME=MyDevice
 ```
 
 When undefined, the client will default to Leasify's production API.
-When `VITE_DEVICE_NAME` is not set, login requests will omit the `device_name`
+When `DEVICE_NAME` is not set, login requests will omit the `device_name`
 parameter.
 
 ## Authentication
@@ -56,6 +56,7 @@ Logga in med e-postadress och lösenord mot `/login`-endpointen. Svaret
 innehåller en token som ska sparas i `localStorage` under nyckeln
 `token`. Axios-klienten läser automatiskt detta värde och skickar det som
 `Bearer` i `Authorization`-headern för alla efterföljande anrop.
+Vid misslyckad inloggning visas felmeddelandet från servern.
 
 ## Development
 

--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -8,8 +8,8 @@ export function ping() {
 // in localStorage and used as a bearer token for subsequent requests.
 export function login(email, password) {
   const deviceName =
-    import.meta?.env?.VITE_DEVICE_NAME ||
-    (typeof process !== 'undefined' ? process.env.VITE_DEVICE_NAME : undefined);
+    import.meta?.env?.DEVICE_NAME ||
+    (typeof process !== 'undefined' ? process.env.DEVICE_NAME : undefined);
   const payload = { email, password };
   if (deviceName) payload.device_name = deviceName;
   return client.post('/login', payload);

--- a/src/api/auth.test.js
+++ b/src/api/auth.test.js
@@ -3,8 +3,8 @@ import client from './client.js';
 import { login } from './auth.js';
 
 describe('login', () => {
-  it('includes device_name when VITE_DEVICE_NAME is set', async () => {
-    process.env.VITE_DEVICE_NAME = 'MyDevice';
+  it('includes device_name when DEVICE_NAME is set', async () => {
+    process.env.DEVICE_NAME = 'MyDevice';
     const mock = new MockAdapter(client);
     mock.onPost('/login').reply(200, { token: 'ok' });
 
@@ -17,10 +17,10 @@ describe('login', () => {
     });
 
     mock.restore();
-    delete process.env.VITE_DEVICE_NAME;
+    delete process.env.DEVICE_NAME;
   });
 
-  it('omits device_name when VITE_DEVICE_NAME is not set', async () => {
+  it('omits device_name when DEVICE_NAME is not set', async () => {
     const mock = new MockAdapter(client);
     mock.onPost('/login').reply(200, { token: 'ok' });
 

--- a/src/api/client.js
+++ b/src/api/client.js
@@ -2,8 +2,13 @@ import axios from 'axios';
 
 // Allow overriding the API base URL using an environment variable. If none is
 // provided, default to Leasify's production API.
+const apiBase =
+  import.meta?.env?.API_BASE_URL ||
+  (typeof process !== 'undefined' ? process.env.API_BASE_URL : undefined) ||
+  'https://app.leasify.se/api/v3';
+
 const client = axios.create({
-  baseURL: import.meta?.env?.VITE_API_BASE_URL || 'https://app.leasify.se/api/v3',
+  baseURL: apiBase,
   withCredentials: true,
 });
 

--- a/src/components/LoginForm.jsx
+++ b/src/components/LoginForm.jsx
@@ -13,7 +13,8 @@ export default function LoginForm({ onLogin }) {
       if (onLogin) onLogin();
     } catch (err) {
       console.error(err);
-      alert('Login failed');
+      const msg = err?.response?.data?.message || err.message || 'Unknown error';
+      alert(`Login failed: ${msg}`);
     }
   };
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,4 +3,8 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  define: {
+    'import.meta.env.API_BASE_URL': JSON.stringify(process.env.API_BASE_URL),
+    'import.meta.env.DEVICE_NAME': JSON.stringify(process.env.DEVICE_NAME),
+  },
 });


### PR DESCRIPTION
## Summary
- rename VITE_API_BASE_URL -> API_BASE_URL
- rename VITE_DEVICE_NAME -> DEVICE_NAME
- expose new variables in Vite config
- show server error message on failed login
- update README and .env.example
- update tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6863e68547b88322b4ea7bc47c3c63f2