### PR TITLE
Default device name

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ DEVICE_NAME=MyDevice
 ```
 
 When undefined, the client will default to Leasify's production API.
-When `DEVICE_NAME` is not set, login requests will omit the `device_name`
-parameter.
+When `DEVICE_NAME` is not set, login requests will use `ACME` as the
+`device_name` parameter.
 
 ## Authentication
 

--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -9,9 +9,9 @@ export function ping() {
 export function login(email, password) {
   const deviceName =
     import.meta?.env?.DEVICE_NAME ||
-    (typeof process !== 'undefined' ? process.env.DEVICE_NAME : undefined);
-  const payload = { email, password };
-  if (deviceName) payload.device_name = deviceName;
+    (typeof process !== 'undefined' ? process.env.DEVICE_NAME : undefined) ||
+    'ACME';
+  const payload = { email, password, device_name: deviceName };
   return client.post('/login', payload);
 }
 

--- a/src/api/auth.test.js
+++ b/src/api/auth.test.js
@@ -20,7 +20,7 @@ describe('login', () => {
     delete process.env.DEVICE_NAME;
   });
 
-  it('omits device_name when DEVICE_NAME is not set', async () => {
+  it('uses ACME as device_name when DEVICE_NAME is not set', async () => {
     const mock = new MockAdapter(client);
     mock.onPost('/login').reply(200, { token: 'ok' });
 
@@ -29,6 +29,7 @@ describe('login', () => {
     expect(JSON.parse(request.data)).toEqual({
       email: 'user',
       password: 'pass',
+      device_name: 'ACME',
     });
 
     mock.restore();

--- a/src/components/LoginForm.jsx
+++ b/src/components/LoginForm.jsx
@@ -6,7 +6,8 @@ export default function LoginForm({ onLogin }) {
   const [password, setPassword] = useState('');
   const deviceName =
     import.meta?.env?.DEVICE_NAME ||
-    (typeof process !== 'undefined' ? process.env.DEVICE_NAME : undefined);
+    (typeof process !== 'undefined' ? process.env.DEVICE_NAME : undefined) ||
+    'ACME';
 
   const handleSubmit = async (e) => {
     e.preventDefault();


### PR DESCRIPTION
## Summary
- default device name to `ACME`
- document default in README
- update login form and tests for new behavior

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_6863e9594c0c832297c2e72dca6d0858