### PR TITLE
Fix env loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ API_BASE_URL=https://my-api.example.com/api/v3
 DEVICE_NAME=MyDevice
 ```
 
+The Vite configuration loads this file automatically, so any variables
+defined here are available without additional setup.
+
 When undefined, the client will default to Leasify's production API.
 When `DEVICE_NAME` is not set, login requests will use `ACME` as the
 `device_name` parameter.

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,8 +1,10 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { config as loadEnv } from 'dotenv';
+import path from 'path';
 
-loadEnv();
+// Always load environment variables from the project root .env file
+loadEnv({ path: path.resolve(process.cwd(), '.env') });
 
 export default defineConfig({
   plugins: [react()],


### PR DESCRIPTION
## Summary
- ensure Vite always loads `.env`
- document automatic env handling in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6863ee2dc1088322a9d168dfd35ef05d