### PR TITLE
Fix env references for Vite build

### DIFF
--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -8,7 +8,7 @@ export function ping() {
 // in localStorage and used as a bearer token for subsequent requests.
 export function login(email, password) {
   const deviceName =
-    import.meta?.env?.DEVICE_NAME ||
+    (import.meta.env && import.meta.env.DEVICE_NAME) ||
     (typeof process !== 'undefined' ? process.env.DEVICE_NAME : undefined) ||
     'ACME';
   const payload = { email, password, device_name: deviceName };

--- a/src/api/client.js
+++ b/src/api/client.js
@@ -3,7 +3,7 @@ import axios from 'axios';
 // Allow overriding the API base URL using an environment variable. If none is
 // provided, default to Leasify's production API.
 const apiBase =
-  import.meta?.env?.API_BASE_URL ||
+  (import.meta.env && import.meta.env.API_BASE_URL) ||
   (typeof process !== 'undefined' ? process.env.API_BASE_URL : undefined) ||
   'https://app.leasify.se/api/v3';
 

--- a/src/components/LoginForm.jsx
+++ b/src/components/LoginForm.jsx
@@ -5,11 +5,11 @@ export default function LoginForm({ onLogin }) {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const deviceName =
-    import.meta?.env?.DEVICE_NAME ||
+    (import.meta.env && import.meta.env.DEVICE_NAME) ||
     (typeof process !== 'undefined' ? process.env.DEVICE_NAME : undefined) ||
     'ACME';
   const apiBase =
-    import.meta?.env?.API_BASE_URL ||
+    (import.meta.env && import.meta.env.API_BASE_URL) ||
     (typeof process !== 'undefined' ? process.env.API_BASE_URL : undefined) ||
     'https://app.leasify.se/api/v3';
 


### PR DESCRIPTION
## Summary
- access `import.meta.env` directly in API client and auth helpers
- use direct env references in `LoginForm`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6863f133d98883228d26b202978f3850