### PR TITLE
Fix token persistence after login

### DIFF
--- a/src/api/client.js
+++ b/src/api/client.js
@@ -12,6 +12,19 @@ const client = axios.create({
   withCredentials: true,
 });
 
+export function setToken(token) {
+  if (token) {
+    localStorage.setItem('token', token);
+    client.defaults.headers.common.Authorization = `Bearer ${token}`;
+  } else {
+    localStorage.removeItem('token');
+    delete client.defaults.headers.common.Authorization;
+  }
+}
+
+// Initialize default header from any existing token on page load
+setToken(localStorage.getItem('token'));
+
 client.interceptors.request.use((config) => {
   const token = localStorage.getItem('token');
   if (token) config.headers.Authorization = `Bearer ${token}`;

--- a/src/api/client.test.js
+++ b/src/api/client.test.js
@@ -1,5 +1,5 @@
 import MockAdapter from 'axios-mock-adapter';
-import client from './client.js';
+import client, { setToken } from './client.js';
 
 describe('axios client', () => {
   it('adds Authorization header when token exists', async () => {
@@ -13,5 +13,15 @@ describe('axios client', () => {
     expect(request.headers.Authorization).toBe('Bearer my-token');
 
     mock.restore();
+  });
+
+  it('setToken stores token and updates default header', () => {
+    setToken('abc');
+    expect(localStorage.getItem('token')).toBe('abc');
+    expect(client.defaults.headers.common.Authorization).toBe('Bearer abc');
+
+    setToken(null);
+    expect(localStorage.getItem('token')).toBeNull();
+    expect(client.defaults.headers.common.Authorization).toBeUndefined();
   });
 });

--- a/src/components/LoginForm.jsx
+++ b/src/components/LoginForm.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { login } from '../api/auth';
+import { setToken } from '../api/client';
 
 export default function LoginForm({ onLogin }) {
   const [email, setEmail] = useState('');
@@ -17,7 +18,7 @@ export default function LoginForm({ onLogin }) {
     e.preventDefault();
     try {
       const { data } = await login(email, password);
-      localStorage.setItem('token', data.token);
+      setToken(data.token);
       if (onLogin) onLogin();
     } catch (err) {
       console.error(err);


### PR DESCRIPTION
## Summary
- keep Authorization header in axios client after login
- reuse the helper when logging in
- test token persistence

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_b_6863f3f467788322bf69499c7dc5ef57