### PR TITLE
Display server error message in WhoAmI alert

### DIFF
--- a/src/components/WhoAmI.jsx
+++ b/src/components/WhoAmI.jsx
@@ -12,7 +12,8 @@ export default function WhoAmI() {
       setShow(true);
     } catch (err) {
       console.error(err);
-      alert('Failed to load info');
+      const msg = err?.response?.data?.message || err.message || 'Unknown error';
+      alert(`Failed to load info: ${msg}`);
     }
   };
 


### PR DESCRIPTION
## Summary
- show detailed error message in WhoAmI alert when request fails

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6863f735b40883229f5c5feb7ee73169