### PR TITLE
Add header and footer info

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,19 +7,40 @@ import WhoAmI from './components/WhoAmI';
 
 function App() {
   const [loggedIn, setLoggedIn] = useState(false);
+  const deviceName =
+    (import.meta.env && import.meta.env.DEVICE_NAME) ||
+    (typeof process !== 'undefined' ? process.env.DEVICE_NAME : undefined) ||
+    'ACME';
+  const token = localStorage.getItem('token');
 
   useEffect(() => {
     ping().then(() => setLoggedIn(true)).catch(() => setLoggedIn(false));
   }, []);
 
-  if (!loggedIn) return <LoginForm onLogin={() => setLoggedIn(true)} />;
-
-  return (
+  const mainContent = loggedIn ? (
     <div className="max-w-3xl mx-auto mt-6 space-y-6 bg-white p-6 rounded shadow">
       <ReportForm onCreated={() => {}} />
       <ReportList />
       <WhoAmI />
     </div>
+  ) : (
+    <LoginForm onLogin={() => setLoggedIn(true)} />
+  );
+
+  return (
+    <>
+      <header className="bg-brandBlue text-white p-4">
+        <h1 className="text-2xl font-bold" data-testid="device-name">
+          {deviceName}
+        </h1>
+      </header>
+      {mainContent}
+      {loggedIn && token && (
+        <footer className="mt-4 p-2 text-center text-xs text-gray-500">
+          bearer={token}
+        </footer>
+      )}
+    </>
   );
 }
 


### PR DESCRIPTION
## Summary
- show `device_name` as a header across the app
- display active bearer token in the footer after login

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_6863f83a0930832286fba0b76f237159