### PR TITLE
Show bearer token and add logout

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ When `DEVICE_NAME` is not set, login requests will use `ACME` as the
 ## Authentication
 
 Logga in med e-postadress och lösenord mot `/login`-endpointen. Svaret
-innehåller en token som ska sparas i `localStorage` under nyckeln
+innehåller en `bearer`-token som ska sparas i `localStorage` under nyckeln
 `token`. Axios-klienten läser automatiskt detta värde och skickar det som
 `Bearer` i `Authorization`-headern för alla efterföljande anrop.
 Vid misslyckad inloggning visas felmeddelandet från servern.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,7 @@ import LoginForm from './components/LoginForm';
 import ReportForm from './components/ReportForm';
 import ReportList from './components/ReportList';
 import { ping } from './api/auth';
+import { setToken } from './api/client';
 import WhoAmI from './components/WhoAmI';
 
 function App() {
@@ -13,6 +14,11 @@ function App() {
     'ACME';
   const token = localStorage.getItem('token');
 
+  const logout = () => {
+    setToken(null);
+    setLoggedIn(false);
+  };
+
   useEffect(() => {
     ping().then(() => setLoggedIn(true)).catch(() => setLoggedIn(false));
   }, []);
@@ -21,7 +27,10 @@ function App() {
     <div className="max-w-3xl mx-auto mt-6 space-y-6 bg-white p-6 rounded shadow">
       <ReportForm onCreated={() => {}} />
       <ReportList />
-      <WhoAmI />
+      <div className="flex space-x-2">
+        <WhoAmI />
+        <button onClick={logout} className="p-2">Log out</button>
+      </div>
     </div>
   ) : (
     <LoginForm onLogin={() => setLoggedIn(true)} />
@@ -35,9 +44,9 @@ function App() {
         </h1>
       </header>
       {mainContent}
-      {loggedIn && token && (
+      {loggedIn && (
         <footer className="mt-4 p-2 text-center text-xs text-gray-500">
-          bearer={token}
+          bearer={token || ''}
         </footer>
       )}
     </>

--- a/src/api/auth.test.js
+++ b/src/api/auth.test.js
@@ -6,7 +6,7 @@ describe('login', () => {
   it('includes device_name when DEVICE_NAME is set', async () => {
     process.env.DEVICE_NAME = 'MyDevice';
     const mock = new MockAdapter(client);
-    mock.onPost('/login').reply(200, { token: 'ok' });
+    mock.onPost('/login').reply(200, { bearer: 'ok' });
 
     await login('user', 'pass');
     const request = mock.history.post[0];
@@ -22,7 +22,7 @@ describe('login', () => {
 
   it('uses ACME as device_name when DEVICE_NAME is not set', async () => {
     const mock = new MockAdapter(client);
-    mock.onPost('/login').reply(200, { token: 'ok' });
+    mock.onPost('/login').reply(200, { bearer: 'ok' });
 
     await login('user', 'pass');
     const request = mock.history.post[0];

--- a/src/components/LoginForm.jsx
+++ b/src/components/LoginForm.jsx
@@ -18,7 +18,7 @@ export default function LoginForm({ onLogin }) {
     e.preventDefault();
     try {
       const { data } = await login(email, password);
-      setToken(data.token);
+      setToken(data.bearer);
       if (onLogin) onLogin();
     } catch (err) {
       console.error(err);


### PR DESCRIPTION
## Summary
- store bearer from /login
- display bearer token in footer even if empty
- add logout button next to WhoAmI
- adjust docs and tests for new `bearer` field

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6863f9f252c8832284ef8af843617a6e