### PR TITLE
Ensure ping sends bearer token

### DIFF
--- a/src/api/ping.test.js
+++ b/src/api/ping.test.js
@@ -1,0 +1,17 @@
+import MockAdapter from 'axios-mock-adapter';
+import client from './client.js';
+import { ping } from './auth.js';
+
+describe('ping', () => {
+  it('includes Authorization header when token exists', async () => {
+    localStorage.setItem('token', 'my-token');
+    const mock = new MockAdapter(client);
+    mock.onGet('/ping').reply(200);
+
+    await ping();
+    const request = mock.history.get[0];
+    expect(request.headers.Authorization).toBe('Bearer my-token');
+
+    mock.restore();
+  });
+});


### PR DESCRIPTION
## Summary
- add unit test verifying /ping includes bearer token header

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6863fb59ba0883229769c3b62036b24b