### PR TITLE
Add templates modal

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,9 +5,11 @@ import ReportList from './components/ReportList';
 import { ping } from './api/auth';
 import { setToken } from './api/client';
 import WhoAmI from './components/WhoAmI';
+import TemplatesModal from './components/TemplatesModal';
 
 function App() {
   const [loggedIn, setLoggedIn] = useState(false);
+  const [showTemplates, setShowTemplates] = useState(false);
   const deviceName =
     (import.meta.env && import.meta.env.DEVICE_NAME) ||
     (typeof process !== 'undefined' ? process.env.DEVICE_NAME : undefined) ||
@@ -26,6 +28,9 @@ function App() {
   const mainContent = loggedIn ? (
     <div className="max-w-3xl mx-auto mt-6 space-y-6 bg-white p-6 rounded shadow">
       <ReportForm onCreated={() => {}} />
+      <button onClick={() => setShowTemplates(true)} className="p-2">
+        Templates
+      </button>
       <ReportList />
       <div className="flex space-x-2">
         <WhoAmI />
@@ -44,6 +49,9 @@ function App() {
         </h1>
       </header>
       {mainContent}
+      {showTemplates && (
+        <TemplatesModal onClose={() => setShowTemplates(false)} />
+      )}
       {loggedIn && (
         <footer className="mt-4 p-2 text-center text-xs text-gray-500">
           bearer={token || ''}

--- a/src/api/templates.js
+++ b/src/api/templates.js
@@ -1,0 +1,5 @@
+import client from './client';
+
+export function getTemplates() {
+  return client.get('/templates');
+}

--- a/src/api/templates.test.js
+++ b/src/api/templates.test.js
@@ -1,0 +1,15 @@
+import MockAdapter from 'axios-mock-adapter';
+import client from './client.js';
+import { getTemplates } from './templates.js';
+
+describe('getTemplates', () => {
+  it('requests /templates', async () => {
+    const mock = new MockAdapter(client);
+    mock.onGet('/templates').reply(200, [{ id: 1 }]);
+
+    const res = await getTemplates();
+    expect(res.data).toEqual([{ id: 1 }]);
+
+    mock.restore();
+  });
+});

--- a/src/components/TemplatesModal.jsx
+++ b/src/components/TemplatesModal.jsx
@@ -1,0 +1,56 @@
+import { useEffect, useState } from 'react';
+import { getTemplates } from '../api/templates';
+
+export default function TemplatesModal({ onClose }) {
+  const [templates, setTemplates] = useState([]);
+
+  useEffect(() => {
+    getTemplates()
+      .then((res) => setTemplates(res.data))
+      .catch((err) => {
+        console.error(err);
+        alert('Failed to load templates');
+      });
+  }, []);
+
+  useEffect(() => {
+    function handleKey(e) {
+      if (e.key === 'Escape') onClose();
+    }
+    document.addEventListener('keydown', handleKey);
+    return () => document.removeEventListener('keydown', handleKey);
+  }, [onClose]);
+
+  const headers = templates.length > 0 ? Object.keys(templates[0]) : [];
+
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50">
+      <div className="bg-white p-4 rounded shadow max-h-[80vh] overflow-auto">
+        <button onClick={onClose} className="float-right p-1 mb-2">Close</button>
+        <table className="table-auto border-collapse w-full text-sm">
+          <thead>
+            <tr>
+              {headers.map((h) => (
+                <th key={h} className="border px-2 py-1 text-left">
+                  {h}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {templates.map((t, i) => (
+              <tr key={i}>
+                {headers.map((h) => (
+                  <td key={h} className="border px-2 py-1">
+                    {String(t[h])}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add API call for templates and a test for it
- add modal component to list templates and close with ESC
- add Templates button to open modal

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_68651c475f9c8322a3505f7308d407ee